### PR TITLE
Add time control and ensure some more openGL stuff is freed on close

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,8 +27,9 @@ Run the binary, and the program will automatically run in fullscreen. You can ex
 
 Controls are as follows:
 - ´´´Arrow keys´´´ for moving the camera.
-- ´´´+ / -´´´ for zooming in/out. Will zoom further when held. May be mapped incorrectly for your keyboard.
+- ´´´PG UP / PG DN´´´ for zooming in/out. Will zoom further when held.
+- ´´´HOME / END´´´ for increasing or decreasing the time scale of the simulation. (WARNING: VERY UNSTABLE AT HIGH SPEED)
 - ´´´LClick´´´ for adding a particle at the mouse.
 - ´´´RClick´´´ for removing the nearest particle to the mouse.
-- ´´´Esc´´´ to close the program
-- ´´´F´´´ to start following particle nearest to mouse, or stop following currently followed particle;
+- ´´´Esc´´´ to close the program.
+- ´´´F´´´ to start following particle nearest to mouse, or stop following currently followed particle.

--- a/src/application.cpp
+++ b/src/application.cpp
@@ -162,7 +162,12 @@ void GravitySimApplication::initializeGraphics()
 }
 void GravitySimApplication::destroyGraphics()
 {
+    glDeleteBuffers(1, &gVBO);
+    glDeleteBuffers(1, &gIBO);
+
     glDeleteProgram(gProgramID);
+
+    SDL_GL_DeleteContext(gContext);
 
     SDL_DestroyWindow(window);
     window = NULL;
@@ -252,6 +257,8 @@ void GravitySimApplication::loadSimulationState()
     // asteroid belt
     simulation.generateParticles(5e-9, Vec2(2.6 * astronomicalUnit, -0.1 * astronomicalUnit), Vec2(2.8 * astronomicalUnit, 0.1 * astronomicalUnit), Vec2(0.0, 18500.0));
 
+    simulation.setTimeScale(1e7);
+
     camera.startFollowing(simulation.getClosestPositionPointer(Vec2(0.0, 0.0)));
     camera.setScale(2.5e-13);
 }
@@ -292,6 +299,13 @@ void GravitySimApplication::handleEvents()
                     Vec2* positionToFollow = simulation.getClosestPositionPointer(worldMousePosition);
                     camera.startFollowing(positionToFollow);
                 }
+                break;
+            case SDL_SCANCODE_HOME:
+                simulation.increaseTimeScale(2.0);
+                break;
+            case SDL_SCANCODE_END:
+                simulation.decreaseTimeScale(2.0);
+                break;
             default:
                 break;
             }

--- a/src/input.cpp
+++ b/src/input.cpp
@@ -28,9 +28,9 @@ void Input::updateInputs()
         inputArray[2] = true;
     if (keyboardState[SDL_SCANCODE_LEFT])
         inputArray[3] = true;
-    if (keyboardState[45])
+    if (keyboardState[SDL_SCANCODE_PAGEUP])
         inputArray[4] = true;
-    if (keyboardState[56])
+    if (keyboardState[SDL_SCANCODE_PAGEDOWN])
         inputArray[5] = true;
 }
 
@@ -40,4 +40,3 @@ bool Input::downPressed() { return inputArray[2]; }
 bool Input::leftPressed() { return inputArray[3]; }
 bool Input::zoomInPressed() { return inputArray[4]; }
 bool Input::zoomOutPressed() { return inputArray[5]; }
-

--- a/src/particles.cpp
+++ b/src/particles.cpp
@@ -62,6 +62,15 @@ void Particles::getFrameData(unsigned int &particleCount, std::vector<Vec2> &pos
     previousAttractorArray = m_previousAttractorArray;
 }
 
+void Particles::storePreviousPositions()
+{
+    m_previousPositionArray.resize(m_particleCount);
+    m_previousAttractorArray.resize(m_attractorCount);
+
+    m_previousPositionArray = m_positionArray;
+    m_previousAttractorArray = m_attractorArray;
+}
+
 void Particles::tick(double delta)
 {
     Vec2 dPos;
@@ -153,15 +162,6 @@ Vec2* Particles::getClosestPositionPointer(Vec2 position)
     }
 
     return &m_attractorArray[closestIndex].position;
-}
-
-void Particles::storePreviousPositions()
-{
-    m_previousPositionArray.resize(m_particleCount);
-    m_previousAttractorArray.resize(m_attractorCount);
-
-    m_previousPositionArray = m_positionArray;
-    m_previousAttractorArray = m_attractorArray;
 }
 
 void Particles::removeAttractor(unsigned int index)

--- a/src/particles.hpp
+++ b/src/particles.hpp
@@ -16,6 +16,8 @@ public:
 
     void getFrameData(unsigned int &particleCount, std::vector<Vec2> &positionArray, std::vector<Vec2> &previousPositionArray, unsigned int &attractorCount, std::vector<Attractor> &attractorArray, std::vector<Attractor> &previousAttractorArray);
 
+    void storePreviousPositions();
+
     void tick(double delta);
 
     void addAttractor(Vec2 position, double mass);
@@ -24,9 +26,6 @@ public:
     void removeAttractor(Vec2 position);
 
     Vec2* getClosestPositionPointer(Vec2 position);
-
-    void storePreviousPositions();
-
 private:
     unsigned int m_particleCount;
     std::vector<Vec2> m_positionArray;

--- a/src/simulation.cpp
+++ b/src/simulation.cpp
@@ -7,6 +7,7 @@
 
 GravitySimSimulation::GravitySimSimulation()
 {
+    timeScale = 1.0;
 }
 
 void GravitySimSimulation::generateParticles(double linearDensity, Vec2 topLeft, Vec2 bottomRight, Vec2 initialVelocity)
@@ -46,6 +47,11 @@ void GravitySimSimulation::getFrameData(unsigned int &particleCount, std::vector
     particles.storePreviousPositions();
 }
 
+void GravitySimSimulation::storePreviousPositions()
+{
+    particles.storePreviousPositions();
+}
+
 void GravitySimSimulation::addAttractor(Vec2 position, double mass)
 {
     particles.addAttractor(position, mass);
@@ -65,9 +71,22 @@ Vec2* GravitySimSimulation::getClosestPositionPointer(Vec2 position)
     return particles.getClosestPositionPointer(position);
 }
 
-void GravitySimSimulation::storePreviousPositions()
+void GravitySimSimulation::setTimeScale(double newTimeScale)
 {
-    particles.storePreviousPositions();
+    timeScale = newTimeScale;
+}
+double GravitySimSimulation::getTimeScale()
+{
+    return timeScale;
+}
+
+void GravitySimSimulation::increaseTimeScale(double factor)
+{
+    timeScale *= factor;
+}
+void GravitySimSimulation::decreaseTimeScale(double factor)
+{
+    timeScale /= factor;
 }
 
 std::chrono::steady_clock::time_point GravitySimSimulation::now()
@@ -77,5 +96,5 @@ std::chrono::steady_clock::time_point GravitySimSimulation::now()
 
 void GravitySimSimulation::tick(double delta)
 {
-    particles.tick(delta * 1e7);
+    particles.tick(delta * timeScale);
 }

--- a/src/simulation.hpp
+++ b/src/simulation.hpp
@@ -18,6 +18,8 @@ public:
 
     void getFrameData(unsigned int &particleCount, std::vector<Vec2> &positionArray, std::vector<Vec2> &previousPositionArray, unsigned int &attractorCount, std::vector<Attractor> &attractorArray, std::vector<Attractor> &previousAttractorArray);
 
+    void storePreviousPositions();
+
     void addAttractor(Vec2 position, double mass);
     void addAttractor(Vec2 position, Vec2 velocity, double mass);
 
@@ -25,10 +27,16 @@ public:
 
     Vec2* getClosestPositionPointer(Vec2 position);
 
-    void storePreviousPositions();
+    void setTimeScale(double newTimeScale);
+    double getTimeScale();
+
+    void increaseTimeScale(double factor);
+    void decreaseTimeScale(double factor);
 
 private:
     bool running;
+
+    double timeScale;
 
     // double tickRate;
 


### PR DESCRIPTION
As the title says. The keys for zoom have also been changed, now zoom and time control buttons are all adjacent.
The openGL frees were not "neccesary" per se, but could potentially help avoid a couple of megabytes of RAM usage after the program closes.
README updated to reflect input changes.